### PR TITLE
Add Global MCP Documentation Tool Usage Rules

### DIFF
--- a/docs/rules/global-custom.mdc
+++ b/docs/rules/global-custom.mdc
@@ -1,144 +1,64 @@
 ---
-description:
+description: Rules for when to use the Global MCP documentation tools
 globs:
 alwaysApply: true
 ---
 
-# Run Custom Development Utility System
+# Global MCP Documentation Tool Usage Rules
 
-This project uses a powerful development utility system called **`run custom`** for automating project tasks. This is the primary tool for running scripts and should be used for most development automation needs.
+## When to Use Global MCP Tools
 
-## How Run Custom Works
+The Global MCP tools should **ONLY** be called when users are clearly and explicitly talking about **global documentation** that needs to be updated, managed, or accessed from remote GitHub repositories.
 
-The `run custom` system executes TypeScript scripts from the [scripts/](mdc:scripts) directory using a standardized pattern:
+## Clear Usage Indicators
 
-```bash
-run custom <script_name> [arguments...] [--flags]
-```
+Use Global MCP tools when users mention:
 
-## Script Structure Pattern
+- **"global documentation"** - explicitly mentions global docs
+- **"update global docs"** - clear reference to global documentation
+- **"manage global configuration"** - refers to global config management
+- **"remote GitHub documentation"** - specifically mentions remote repository docs
+- **"cross-repository documentation"** - indicates documentation spread across repositories
+- **"centralized documentation"** - implies global/centralized doc management
 
-All custom scripts follow this exact pattern:
+## DO NOT Use Global MCP Tools
 
-```typescript
-import type { CustomArgs, CustomOptions } from 'jsr:@ghostmind/run';
-import { $ } from 'npm:zx';
+**do NOT** use Global MCP tools when users only mention:
 
-export default async function (args: CustomArgs, opts: CustomOptions) {
-  // Script logic here
-  // args[0] = first argument, args[1] = second argument, etc.
-  // opts.has('flag-name') = check for boolean flags
-  // opts.extract('key') = extract key-value flags
-  // opts.env = environment variables
-  // opts.currentPath = current working directory
-}
-```
+- **"update documentation"** - generic documentation reference
+- **"modify docs"** - local documentation implied
+- **"add documentation"** - could be local project docs
+- **"fix the README"** - typically local file changes
+- **"update the docs"** - ambiguous, likely local
 
-## Current Scripts in This Project
+## Key Distinction
 
-### Test Script ([scripts/test.ts](mdc:scripts/test.ts))
+The user must be **explicitly clear** about wanting to work with:
+- Documentation that spans multiple repositories
+- Centralized/global documentation systems
+- Remote GitHub repository documentation management
+- Cross-project documentation coordination
 
-The test script is used to test DevContainer features locally. It supports multiple modes and options:
+## Examples
 
-#### Basic Usage
+### ✅ **CORRECT Usage** - Use Global MCP Tools:
+- "I want to update our global documentation about deployment"
+- "Can you help me manage the global configuration docs?"
+- "I need to add to our centralized documentation repository"
+- "Update the global rules documentation"
 
-```bash
-# List all available features (no arguments)
-run custom test
+### ❌ **INCORRECT Usage** - Do NOT Use Global MCP Tools:
+- "I want to update the documentation" (too generic)
+- "Can you help me write some docs?" (local context implied)
+- "Fix the documentation in this project" (local scope)
+- "Add documentation for this feature" (project-specific)
 
-# Test all scenarios for a specific feature
-run custom test <feature-name>
+## When in Doubt
 
-# Test a specific scenario for a feature
-run custom test <feature-name> <scenario-name>
-```
+If the user's request is ambiguous, **ask for clarification** before using Global MCP tools:
 
-#### Information Commands
+*"Are you referring to updating global/centralized documentation that spans multiple repositories, or documentation within this specific project?"*
 
-```bash
-# List available scenarios for a feature (as argument, not flag)
-run custom test <feature-name> list-scenarios
+## Purpose
 
-# Examples:
-run custom test aws list-scenarios
-run custom test init list-scenarios
-```
-
-#### Testing Options (as arguments, not flags)
-
-```bash
-# Run with verbose output
-run custom test <feature> verbose
-run custom test <feature> <scenario> verbose
-
-# Keep containers after test (for debugging)
-run custom test <feature> no-cleanup
-
-# Skip installing common utilities
-run custom test <feature> no-common-utils
-
-# Combine options
-run custom test <feature> verbose no-cleanup
-```
-
-#### Complete Examples
-
-```bash
-# List all testable features
-run custom test
-
-# Test all scenarios for the init feature
-run custom test init
-
-# Test specific scenario with verbose output
-run custom test init test_enabled verbose
-
-# List scenarios for a feature
-run custom test init list-scenarios
-
-# Test with debugging (keep containers)
-run custom test aws no-cleanup verbose
-```
-
-#### Important Notes for Test Script
-
-- Features must have both `features/src/<name>/` and `features/test/<name>/` directories to be testable
-- Each feature needs a `scenarios.json` file in its test directory
-- Options are passed as **arguments**, not as `--flags`
-- The test system automatically includes common-utils unless `no-common-utils` is specified
-- Use `list-scenarios` as an argument (not `--list-scenarios` flag)
-- Available features are shown when running `run custom test` with no arguments
-
-### Publish Script ([scripts/publish.ts](mdc:scripts/publish.ts))
-
-```bash
-# Publish all DevContainer features to registry
-run custom publish
-```
-
-## Key Features of Run Custom
-
-- **Rich Context**: Scripts receive environment variables, current path, and utility functions
-- **Argument Parsing**: Easy access to positional arguments and flags
-- **ZX Integration**: Built-in shell command execution with `$` from npm:zx
-- **Type Safety**: Full TypeScript support with proper type definitions
-- **Development Utility**: This is the main development tool - most scripts you create should use this system
-
-## When to Use Run Custom
-
-Use `run custom` for:
-
-- Build automation
-- Testing workflows
-- Publishing and deployment
-- Development setup tasks
-- Complex multi-step operations
-- Project-specific utilities
-
-## Important Notes
-
-- All scripts must be in the [scripts/](mdc:scripts) directory
-- Scripts must export a default async function
-- Always import types from `jsr:@ghostmind/run`
-- Use `npm:zx` for shell operations
-- This is the preferred way to create development automation in this project
+This rule ensures that the Global MCP tools are used appropriately and prevents unnecessary calls to remote GitHub repositories when users are working with local project documentation.


### PR DESCRIPTION
This rule defines when the Global MCP tools should be used - only when users are explicitly talking about global documentation that needs to be updated, not generic documentation requests.

Key points:
- Requires explicit mention of "global documentation" or similar terms
- Prevents unnecessary calls to remote GitHub repositories for local documentation
- Provides clear examples of correct vs incorrect usage
- Includes guidance for handling ambiguous requests